### PR TITLE
Corrigir compatibilidade com nova API do NYT

### DIFF
--- a/src/raspe/scrapers/nyt.py
+++ b/src/raspe/scrapers/nyt.py
@@ -197,7 +197,10 @@ class ScraperNYT(BaseScraper):
                 error_msg = data.get('message', str(data))
                 raise APIError(f"Resposta inválida da API: {error_msg}")
 
+            # API mudou de 'meta' para 'metadata' em 2024
             meta = data.get('response', {}).get('meta', {})
+            if not meta:
+                meta = data.get('response', {}).get('metadata', {})
             total_hits = meta.get('hits', 0)
 
             n_pags = (total_hits + self.RESULTS_PER_PAGE - 1) // self.RESULTS_PER_PAGE


### PR DESCRIPTION
## Summary
- A API do New York Times mudou o campo de metadados de `meta` para `metadata` em 2024
- Agora o scraper verifica ambos os campos para manter compatibilidade retroativa

## Mudança
```python
# API mudou de 'meta' para 'metadata' em 2024
meta = data.get('response', {}).get('meta', {})
if not meta:
    meta = data.get('response', {}).get('metadata', {})
```

## Test plan
- [ ] Testar raspagem do NYT com API key válida

🤖 Generated with [Claude Code](https://claude.com/claude-code)