### PR TITLE
Reduce Python version requirement and fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ O RasPe automatiza a coleta de dados de fontes oficiais brasileiras:
 
 Você precisará ter o **Python** instalado no seu computador. Se ainda não tem:
 
-1. **Windows/Mac:** Baixe em [python.org/downloads](https://www.python.org/downloads/) (versão 3.11 ou superior)
+1. **Windows/Mac:** Baixe em [python.org/downloads](https://www.python.org/downloads/) (versão 3.10 ou superior)
 2. **Linux:** Geralmente já vem instalado. Se não, use: `sudo apt install python3 python3-pip`
 
 ### Instalando o RasPe
@@ -46,6 +46,22 @@ pip install git+https://github.com/bdcdo/raspe.git
 ```
 
 **Pronto!** O RasPe está instalado e pronto para uso.
+
+### 🎯 Compatibilidade com Google Colab
+
+O RasPe é **totalmente compatível com Google Colab**! Você pode usar a ferramenta diretamente no navegador, sem precisar instalar Python no seu computador.
+
+Para usar no Google Colab:
+
+1. Acesse [colab.research.google.com](https://colab.research.google.com/)
+2. Crie um novo notebook
+3. Na primeira célula, instale o RasPe:
+   ```python
+   !pip install git+https://github.com/bdcdo/raspe.git
+   ```
+4. Execute a célula e comece a usar!
+
+O Google Colab já vem com Python 3.10 pré-instalado, que é perfeitamente compatível com o RasPe.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "raspe"
 version = "0.1.0"
 description = "Raspadores para Pesquisas Acadêmicas - ferramentas para coleta de dados de fontes brasileiras"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [
     { name = "Bruno da Cunha de Oliveira", email = "bruno.dcdo@gmail.com" },
 ]
@@ -41,7 +41,7 @@ addopts = "-v -s --cov=src/raspe --cov-report=html --cov-report=term-missing"
 
 [tool.black]
 line-length = 100
-target-version = ['py312']
+target-version = ['py310']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
- Atualizar pyproject.toml para requires-python = ">=3.10"
- Atualizar target-version do black para py310
- Atualizar README com versão correta do Python (3.10+)
- Adicionar seção sobre compatibilidade com Google Colab no README

Isso torna o RasPe compatível com Google Colab, que usa Python 3.10 por padrão. A análise do código mostrou que a versão mínima real necessária é 3.10 (devido ao uso do operador | para union types), não 3.11 como estava configurado anteriormente.

Closes #23