### PR TITLE
Close resolved issues in repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "raspe"
 version = "0.1.0"
 description = "Raspadores para Pesquisas Acadêmicas - ferramentas para coleta de dados de fontes brasileiras"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [
     { name = "Bruno da Cunha de Oliveira", email = "bruno.dcdo@gmail.com" },
 ]
@@ -27,6 +27,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "ipykernel>=7.1.0",
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
- Alterar requires-python de >=3.11 para >=3.10
- Adicionar pytest e pytest-cov às dependências de desenvolvimento
- Código não usa features específicas do 3.11 (sem typing.Self ou tomllib)
- Usa apenas union types com | (disponível desde Python 3.10)

Resolve #23
Resolve #5