### PR TITLE
Fundação de testes (Fase 0): responses + pytest-mock + helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,61 @@ Novos scrapers devem:
 - Hooks rodam em cada commit: trailing whitespace, isort, pylint, flake8, mypy, pyright
 - Comprimento máximo de linha: 120
 - Para rodar todos os hooks manualmente: `pre-commit run --all-files`
+
+## Testes
+
+A suíte usa `pytest` + `responses` + `pytest-mock` para contratos offline,
+sem tocar a rede. Convenção:
+
+- Por scraper: `tests/<scraper>/test_<método>_contract.py`.
+- Samples reais commitados em `tests/<scraper>/samples/<endpoint>/<cenario>.<ext>`.
+- Helpers: `tests/_helpers.py` expõe `load_sample()` e `load_sample_bytes()`.
+- Captura de samples: `tests/fixtures/capture/<scraper>.py` (script ad-hoc).
+
+Comandos úteis:
+
+```bash
+pytest -m "not integration"           # padrão, exclui integração
+pytest tests/<scraper>/ -v            # só um scraper
+pytest --cov=src/raspe                # com cobertura
+```
+
+Markers disponíveis: `slow`, `integration`. `filterwarnings = ["error"]`
+está ativo — qualquer warning não capturado vira erro de teste.
+
+### Checklist obrigatória ao adicionar um novo scraper
+
+Todo scraper novo em `src/raspe/scrapers/<xx>.py` deve entrar acompanhado
+de **pelo menos um teste de contrato** por método público (`raspar` e
+qualquer método adicional). O PR fica bloqueado sem isso.
+
+1. **Script de captura** em `tests/fixtures/capture/<xx>.py` que exercita
+   o scraper real e salva as respostas cruas em
+   `tests/<xx>/samples/<endpoint>/<cenario>.<ext>`. Mínimo 3 cenários por
+   endpoint: typical (paginação), single_page, no_results.
+2. **Samples commitados** em `tests/<xx>/samples/<endpoint>/`.
+   Convenção: `page_01.html`, `page_02.html`, `single_page.html`,
+   `no_results.html` (ou extensão apropriada — `.json`, etc.).
+3. **Teste de contrato** em `tests/<xx>/test_raspar_contract.py`:
+   - `@responses.activate` decorator.
+   - `mocker.patch("time.sleep")` em toda função com paginação.
+   - `responses.add(..., body=load_sample_bytes("<xx>", "raspar/<cenario>.<ext>"))`
+     para cada request esperado.
+   - Matcher de payload sempre que possível:
+     - `urlencoded_params_matcher(..., strict_match=False)` para POST form.
+     - `json_params_matcher(...)` para POST JSON.
+     - `query_param_matcher(...)` para GET.
+   - Schema validado por **subset**: `{"col_a", "col_b"} <= set(df.columns)`.
+     Nunca igualdade.
+   - Pelo menos 3 casos: typical, single_page, no_results.
+4. **Sem `@pytest.mark.integration`** no contrato.
+5. **Sem dependência de rede, relógio ou TLS real**. Adapter custom
+   (ex.: SSL desabilitado): testar só configuração (`isinstance`).
+6. **Fluxos multi-step com ordem obrigatória** usam
+   `responses.registries.OrderedRegistry`.
+7. **Captchas, tokens dinâmicos, lazy imports** (ex.: `txtcaptcha`,
+   `browser_cookie3`) são **mockados** via `mocker.patch.dict(sys.modules, ...)`,
+   nunca invocados de verdade.
+8. **CHANGELOG**: a adição de novo scraper já é uma entrada `Adicionado`;
+   adicionar testes para scraper existente é mudança interna e não
+   precisa de entrada (ver "Versionamento e CHANGELOG" acima).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,8 @@ sem tocar a rede. Convenção:
 Comandos úteis:
 
 ```bash
-pytest -m "not integration"           # padrão, exclui integração
+pytest                                # padrão (exclui integração via addopts)
+pytest -m integration                 # só testes de integração
 pytest tests/<scraper>/ -v            # só um scraper
 pytest --cov=src/raspe                # com cobertura
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dev = [
     "ipykernel>=7.1.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "pytest-mock>=3.12.0",
+    "responses>=0.25.0",
     "pylint>=3.0.0",
     "isort>=5.12.0",
     "flake8>=6.0.0",
@@ -54,7 +56,17 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_functions = "test_*"
 python_classes = "Test*"
-addopts = "-v -s --cov=src/raspe --cov-report=html --cov-report=term-missing"
+addopts = "-v -ra --strict-markers --strict-config -m 'not integration' --cov=src/raspe --cov-report=html --cov-report=term-missing"
+markers = [
+    "slow: testes que levam mais de alguns segundos",
+    "integration: testes que tocam a rede ou serviços externos (excluídos por padrão)",
+]
+filterwarnings = [
+    "error",
+    # urllib3 InsecureRequestWarning é silenciado pelo ScraperPresidencia no construtor,
+    # mas pode escapar antes do silenciamento durante import. Mantemos como warning.
+    "default::urllib3.exceptions.InsecureRequestWarning",
+]
 
 [tool.pylint.main]
 load-plugins = ["pylint.extensions.docparams"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.12.0",
-    "responses>=0.25.0",
+    "responses>=0.25.0,<1.0.0",
     "pylint>=3.0.0",
     "isort>=5.12.0",
     "flake8>=6.0.0",
@@ -56,7 +56,7 @@ testpaths = ["tests"]
 python_files = "test_*.py"
 python_functions = "test_*"
 python_classes = "Test*"
-addopts = "-v -ra --strict-markers --strict-config -m 'not integration' --cov=src/raspe --cov-report=html --cov-report=term-missing"
+addopts = "-v -ra --strict-markers --strict-config --import-mode=importlib -m 'not integration' --cov=src/raspe --cov-report=html --cov-report=term-missing"
 markers = [
     "slow: testes que levam mais de alguns segundos",
     "integration: testes que tocam a rede ou serviços externos (excluídos por padrão)",

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,62 @@
+"""Helpers compartilhados pela suíte de testes.
+
+Funções para carregar samples (HTML/JSON/etc.) capturados de respostas reais
+e versionados em `tests/<scraper>/samples/`. Usados pelos contratos offline
+com `responses`.
+"""
+
+from pathlib import Path
+
+_TESTS_DIR = Path(__file__).parent
+
+
+def _resolve(scraper: str, relative_path: str) -> Path:
+    """Resolve o caminho absoluto de um sample.
+
+    Args:
+        scraper: Nome do scraper (ex.: "presidencia", "ipea").
+        relative_path: Caminho relativo dentro de `tests/<scraper>/samples/`.
+
+    Returns:
+        Path absoluto do arquivo de sample.
+
+    Raises:
+        FileNotFoundError: Se o sample não existir no caminho esperado.
+    """
+    path = _TESTS_DIR / scraper / "samples" / relative_path
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Sample não encontrado: {path}. "
+            f"Capture com `python tests/fixtures/capture/{scraper}.py`."
+        )
+    return path
+
+
+def load_sample(scraper: str, relative_path: str, *, encoding: str = "utf-8") -> str:
+    """Carrega um sample como texto.
+
+    Args:
+        scraper: Nome do scraper.
+        relative_path: Caminho relativo (ex.: "raspar/page_01.html").
+        encoding: Encoding do arquivo (padrão "utf-8"; eSAJ usa "latin-1").
+
+    Returns:
+        Conteúdo do arquivo como string.
+    """
+    return _resolve(scraper, relative_path).read_text(encoding=encoding)
+
+
+def load_sample_bytes(scraper: str, relative_path: str) -> bytes:
+    """Carrega um sample como bytes.
+
+    Útil quando o `responses.add(body=...)` precisa de bytes para preservar
+    o encoding original (ex.: páginas em latin-1) ou para arquivos binários.
+
+    Args:
+        scraper: Nome do scraper.
+        relative_path: Caminho relativo (ex.: "raspar/page_01.html").
+
+    Returns:
+        Conteúdo do arquivo como bytes.
+    """
+    return _resolve(scraper, relative_path).read_bytes()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,6 @@
 """Configuração compartilhada do pytest para a suíte raspe.
 
-Fornece fixtures básicas para localização de samples. Não inclui fixture
-autouse para mockar `time.sleep` — cada teste com paginação deve usar
-`mocker.patch("time.sleep")` explicitamente para deixar a intenção clara.
+Não inclui fixture autouse para mockar `time.sleep` — cada teste com
+paginação deve usar `mocker.patch("time.sleep")` explicitamente para
+deixar a intenção clara.
 """
-
-from pathlib import Path
-
-import pytest
-
-
-@pytest.fixture(scope="session")
-def tests_dir() -> Path:
-    """Diretório raiz da suíte de testes (`tests/`)."""
-    return Path(__file__).parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Configuração compartilhada do pytest para a suíte raspe.
+
+Fornece fixtures básicas para localização de samples. Não inclui fixture
+autouse para mockar `time.sleep` — cada teste com paginação deve usar
+`mocker.patch("time.sleep")` explicitamente para deixar a intenção clara.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def tests_dir() -> Path:
+    """Diretório raiz da suíte de testes (`tests/`)."""
+    return Path(__file__).parent

--- a/tests/fixtures/capture/README.md
+++ b/tests/fixtures/capture/README.md
@@ -1,0 +1,69 @@
+# Scripts de captura de samples
+
+Cada scraper HTTP do raspe tem um script aqui que **exercita o scraper real
+contra o backend** e salva as respostas cruas em
+`tests/<scraper>/samples/<endpoint>/<cenario>.<ext>`.
+
+Esses samples são a **fonte de verdade** dos contratos offline em
+`tests/<scraper>/test_*_contract.py`. Se o backend do scraper mudar e o
+contrato quebrar, re-rode o script de captura, inspecione o diff, ajuste
+o parser se necessário e commite samples + parser num único PR.
+
+## Por que scripts ad-hoc em vez de gravadores automáticos?
+
+Cassetes VCR (via `pytest-recording`) são úteis para fluxos com estado
+(ViewState, JWT, crypto token), mas para a maioria dos scrapers do raspe
+um script simples que salva cada resposta é mais legível, mais fácil de
+re-rodar e gera samples menores. Adoção de VCR fica caso a caso.
+
+## Como rodar
+
+```bash
+# Pré-requisitos:
+uv pip install -e ".[dev]"
+
+# Rodar a captura de um scraper específico:
+python tests/fixtures/capture/presidencia.py
+```
+
+Cada script grava em `tests/<scraper>/samples/<endpoint>/`. Os samples
+ficam **commitados no repositório** — não estão em `.gitignore`.
+
+## Quando re-rodar
+
+- O contrato `test_*_contract.py` falhou e a causa parece ser mudança no
+  backend (HTML/JSON diferente) e não bug no scraper.
+- Adição de um novo cenário de teste (ex.: novo filtro suportado).
+- Curadoria periódica (ex.: 1× por trimestre) para detectar drift silencioso.
+
+## Variáveis de ambiente necessárias
+
+| Scraper | Env var | Como obter |
+|---|---|---|
+| nyt | `NYT_API_KEY` | https://developer.nytimes.com/get-started |
+
+Outros scrapers não exigem auth.
+
+## Cenários mínimos a capturar por scraper
+
+Cada script deve produzir pelo menos 3 cenários por método público
+(`raspar`, etc.):
+
+1. **typical** — busca que retorna múltiplas páginas (≥2 páginas).
+2. **single_page** — busca que cabe numa página só.
+3. **no_results** — busca que retorna zero resultados.
+
+Convenção de nomes dos arquivos:
+
+```
+tests/<scraper>/samples/<endpoint>/
+    page_01.html       # primeira página da consulta typical
+    page_02.html       # segunda página da consulta typical
+    single_page.html   # cenário de página única
+    no_results.html    # cenário sem resultados
+```
+
+## Helper compartilhado
+
+`_util.py` fornece `dump_response(resp, path)` e `attach_capture_hook(session, dir)`,
+que instrumenta uma `requests.Session` para salvar cada resposta automaticamente.

--- a/tests/fixtures/capture/_util.py
+++ b/tests/fixtures/capture/_util.py
@@ -1,0 +1,90 @@
+"""Utilitário para scripts de captura de samples.
+
+Cada scraper tem um script em `tests/fixtures/capture/<scraper>.py` que
+exercita o scraper real, captura as respostas HTTP cruas e salva em
+`tests/<scraper>/samples/<endpoint>/<cenario>.<ext>`. Esses samples
+viram a fonte de verdade dos contratos offline.
+
+Uso típico em um script de captura:
+
+    from pathlib import Path
+    import requests
+    from tests.fixtures.capture._util import attach_capture_hook
+
+    samples_dir = Path("tests/presidencia/samples/raspar")
+    samples_dir.mkdir(parents=True, exist_ok=True)
+
+    session = requests.Session()
+    attach_capture_hook(session, samples_dir, prefix="page")
+    # ... usa a session para exercitar o scraper ...
+"""
+
+from pathlib import Path
+from typing import Callable
+
+import requests
+
+
+def dump_response(resp: requests.Response, path: Path) -> None:
+    """Salva o body bruto de uma resposta HTTP em disco.
+
+    Cria diretórios pais se necessário. Preserva o encoding original via
+    `resp.content` (bytes), evitando problemas com latin-1/utf-8 mistos.
+
+    Args:
+        resp: Resposta retornada por `requests`.
+        path: Caminho absoluto onde gravar o body.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(resp.content)
+
+
+def attach_capture_hook(
+    session: requests.Session,
+    samples_dir: Path,
+    *,
+    prefix: str = "response",
+    extension: str | None = None,
+) -> Callable[[], None]:
+    """Anexa um hook `response` à sessão que salva cada resposta automaticamente.
+
+    Numera os arquivos sequencialmente: `<prefix>_01.<ext>`, `<prefix>_02.<ext>`,
+    etc. A extensão padrão é inferida do `Content-Type` (`html`, `json`, ou `bin`).
+
+    Args:
+        session: Sessão `requests` a instrumentar.
+        samples_dir: Diretório de saída (será criado).
+        prefix: Prefixo do nome dos arquivos.
+        extension: Extensão fixa; se None, infere de Content-Type.
+
+    Returns:
+        Função para remover o hook (chamar quando terminar a captura).
+    """
+    samples_dir.mkdir(parents=True, exist_ok=True)
+    counter = {"i": 0}
+
+    def _hook(resp: requests.Response, *args, **kwargs) -> requests.Response:
+        counter["i"] += 1
+        ext = extension or _guess_extension(resp)
+        filename = f"{prefix}_{counter['i']:02d}.{ext}"
+        dump_response(resp, samples_dir / filename)
+        return resp
+
+    session.hooks.setdefault("response", []).append(_hook)
+
+    def _detach() -> None:
+        hooks = session.hooks.get("response", [])
+        if _hook in hooks:
+            hooks.remove(_hook)
+
+    return _detach
+
+
+def _guess_extension(resp: requests.Response) -> str:
+    """Infere a extensão do arquivo a partir do Content-Type da resposta."""
+    content_type = resp.headers.get("Content-Type", "").lower()
+    if "json" in content_type:
+        return "json"
+    if "html" in content_type or "xml" in content_type:
+        return "html"
+    return "bin"

--- a/tests/fixtures/capture/_util.py
+++ b/tests/fixtures/capture/_util.py
@@ -20,7 +20,7 @@ Uso típico em um script de captura:
 """
 
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import requests
 
@@ -49,7 +49,7 @@ def attach_capture_hook(
     """Anexa um hook `response` à sessão que salva cada resposta automaticamente.
 
     Numera os arquivos sequencialmente: `<prefix>_01.<ext>`, `<prefix>_02.<ext>`,
-    etc. A extensão padrão é inferida do `Content-Type` (`html`, `json`, ou `bin`).
+    etc. A extensão padrão é inferida do `Content-Type` (`html`, `json`, `xml` ou `bin`).
 
     Args:
         session: Sessão `requests` a instrumentar.
@@ -63,7 +63,7 @@ def attach_capture_hook(
     samples_dir.mkdir(parents=True, exist_ok=True)
     counter = {"i": 0}
 
-    def _hook(resp: requests.Response, *args, **kwargs) -> requests.Response:
+    def _hook(resp: requests.Response, *args: Any, **kwargs: Any) -> requests.Response:
         counter["i"] += 1
         ext = extension or _guess_extension(resp)
         filename = f"{prefix}_{counter['i']:02d}.{ext}"
@@ -85,6 +85,8 @@ def _guess_extension(resp: requests.Response) -> str:
     content_type = resp.headers.get("Content-Type", "").lower()
     if "json" in content_type:
         return "json"
-    if "html" in content_type or "xml" in content_type:
+    if "xml" in content_type:
+        return "xml"
+    if "html" in content_type:
         return "html"
     return "bin"


### PR DESCRIPTION
## Resumo

Estabelece a infraestrutura para testes offline de scrapers, alinhada à estratégia consolidada pelo juscraper ([jtrecenti/juscraper#113](https://github.com/jtrecenti/juscraper/issues/113), [#104](https://github.com/jtrecenti/juscraper/issues/104)). Esta é a **Fase 0** do plano unificado das issues #3 e #4.

A Fase 1 (contratos por scraper) já está rastreada em #30 com o máximo de detalhe — pode rodar isoladamente assim que esta fundação for mergeada.

## Mudanças

- **`pyproject.toml`**: adiciona `responses>=0.25.0` e `pytest-mock>=3.12.0` em `[dev]`. Em `[tool.pytest.ini_options]`: markers (`slow`, `integration`), `filterwarnings = ["error"]` (com exceção para `urllib3.exceptions.InsecureRequestWarning` — silenciada pelo `ScraperPresidencia`), `addopts` com `-m 'not integration'` e `--strict-markers --strict-config`.
- **`tests/_helpers.py`** (novo): `load_sample(scraper, relative_path, encoding="utf-8")` e `load_sample_bytes(scraper, relative_path)`. Resolvem para `tests/<scraper>/samples/`.
- **`tests/conftest.py`** (novo): fixture `tests_dir` (escopo session). Decisão consciente: sem fixture autouse para `time.sleep` — cada teste com paginação usa `mocker.patch("time.sleep")` explicitamente.
- **`tests/__init__.py`** (novo, vazio): ancora o pacote para mypy.
- **`tests/fixtures/capture/_util.py`** (novo): `dump_response(resp, path)` e `attach_capture_hook(session, samples_dir, prefix, extension)` para os scripts ad-hoc de captura de samples reais.
- **`tests/fixtures/capture/README.md`** (novo): como rodar os scripts, quando re-rodar, env vars (`NYT_API_KEY` para o scraper NYT).
- **`CLAUDE.md`**: nova seção "Testes" com convenção (`tests/<scraper>/test_<método>_contract.py` + `tests/<scraper>/samples/<endpoint>/<cenario>.<ext>`) e checklist obrigatória de 8 itens para scrapers novos.

## Por que essa estratégia

Contratos offline com `responses` + samples reais:

1. **Validam a API pública** (entrada → DataFrame de saída) — sobrevivem refactor.
2. **Samples reais** capturados por scripts versionados em `tests/fixtures/capture/<scraper>.py` são parte integrante do contrato.
3. **Offline-first, determinísticos, rápidos**: nenhuma chamada de rede, `time.sleep` mockado, sem dependência de relógio/TLS.
4. **Detectam quebra de propagação de filtros** via matchers (`urlencoded_params_matcher`, `json_params_matcher`, `query_param_matcher`).

O juscraper aplicou essa receita em 21/27 scrapers e expôs 4 bugs reais no processo. Mesmo padrão é replicável aqui.

## Test plan

- [x] `uv pip install -e ".[dev]"` instala `responses==0.26.0`, `pytest-mock==3.15.1`, `pytest-cov==7.1.0`.
- [x] `pytest -m "not integration"` passa: 8/8 testes existentes (`tests/test_utils.py`) em ~1.5s.
- [x] `pre-commit run --files <arquivos novos>`: trailing whitespace, isort, flake8, pyright todos verdes.
- [ ] CI no GitHub valida o mesmo (não há workflow ainda — Fase 3 do plano).

## Notas

- **CHANGELOG não atualizado**: o próprio `CLAUDE.md` (seção "Versionamento e CHANGELOG") explicita que reorganização de testes é mudança interna e não entra. O item 8 da nova checklist deixa isso explícito.
- **Não cobre nenhum scraper ainda**: este PR é **só infraestrutura**. A cobertura por scraper começa na Fase 1 (#30).
- **Sem breaking change**: não toca nenhum arquivo em `src/`.

Refs: #3, #4. Próxima parada: #30 (Fase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)