### PR TITLE
test(coverage): configurar coverage e testar módulos core (PR 1/3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,24 @@ filterwarnings = [
     "default::urllib3.exceptions.InsecureRequestWarning",
 ]
 
+[tool.coverage.run]
+source = ["src/raspe"]
+# playwright_scraper.py é base async para scrapers de navegador e não pode ser
+# testado offline sem mockar a API inteira do Playwright; excluímos do
+# denominador. Os scrapers concretos (datalegis, saudelegis, ans, anvisa)
+# permanecem no denominador e têm testes mínimos de configuração.
+omit = ["src/raspe/playwright_scraper.py"]
+branch = false
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "\\.\\.\\.",
+]
+show_missing = true
+
 [tool.pylint.main]
 load-plugins = ["pylint.extensions.docparams"]
 

--- a/tests/test_abstract_scraper.py
+++ b/tests/test_abstract_scraper.py
@@ -1,0 +1,170 @@
+"""Testes unitários para AbstractScraper.
+
+Usa uma subclasse mínima ``_DummyScraper`` para exercitar os métodos
+concretos da classe abstrata (validação de parâmetros, logger,
+``_create_download_dir``, ``_parse_data``, alias ``scrape``).
+"""
+
+import logging
+import os
+from typing import Literal
+
+import pandas as pd
+import pytest
+
+from raspe.abstract_scraper import AbstractScraper
+from raspe.exceptions import ValidationError
+
+
+class _DummyScraper(AbstractScraper):
+    """Subclasse concreta mínima para testes."""
+
+    @property
+    def type(self) -> Literal['HTML']:
+        return 'HTML'
+
+    def _parse_page(self, path: str) -> pd.DataFrame:
+        # Lê o arquivo e devolve um DataFrame com o conteúdo
+        with open(path, "r", encoding="utf-8") as f:
+            return pd.DataFrame({"path": [path], "content": [f.read()]})
+
+    def raspar(self, **kwargs) -> pd.DataFrame:
+        # Implementação trivial para satisfazer o ABC
+        return pd.DataFrame()
+
+
+class TestInit:
+    def test_atributos_basicos(self):
+        s = _DummyScraper("test_scraper", debug=False)
+        assert s.nome_buscador == "test_scraper"
+        assert s.debug is False
+        assert s.exclude_cols_from_dedup == []
+        assert os.path.isdir(s.download_path)
+
+    def test_logger_configurado(self):
+        s = _DummyScraper("logger_test", debug=True)
+        assert isinstance(s.logger, logging.Logger)
+        assert s.logger.name == "logger_test"
+        assert s.logger.level == logging.DEBUG
+
+    def test_logger_em_modo_info_quando_debug_off(self):
+        s = _DummyScraper("logger_info", debug=False)
+        assert s.logger.level == logging.INFO
+
+    def test_logger_nao_propaga(self):
+        """Para evitar duplicação de logs com o root logger."""
+        s = _DummyScraper("propagate_test")
+        assert s.logger.propagate is False
+
+
+class TestValidarParametros:
+    def test_passa_kwargs_sem_datas(self):
+        s = _DummyScraper("v1")
+        params = s._validar_parametros(pesquisa="termo", ano=2024)
+        assert params == {"pesquisa": "termo", "ano": 2024}
+
+    def test_normaliza_data_inicio_e_fim(self):
+        s = _DummyScraper("v2")
+        params = s._validar_parametros(data_inicio="01/01/2024", data_fim="31/12/2024")
+        assert params["data_inicio"] == "2024-01-01"
+        assert params["data_fim"] == "2024-12-31"
+
+    def test_aliases_begin_end_date(self):
+        s = _DummyScraper("v3")
+        params = s._validar_parametros(begin_date="20240101", end_date="20241231")
+        assert params["begin_date"] == "2024-01-01"
+        assert params["end_date"] == "2024-12-31"
+
+    def test_aliases_inicio_fim(self):
+        s = _DummyScraper("v4")
+        params = s._validar_parametros(inicio="01/01/2024", fim="31/12/2024")
+        assert params["inicio"] == "2024-01-01"
+        assert params["fim"] == "2024-12-31"
+
+    def test_apenas_data_inicio_sem_fim(self):
+        s = _DummyScraper("v5")
+        params = s._validar_parametros(data_inicio="2024-01-01")
+        assert params["data_inicio"] == "2024-01-01"
+
+    def test_data_invalida_propaga_validation_error(self):
+        s = _DummyScraper("v6")
+        with pytest.raises(ValidationError):
+            s._validar_parametros(data_inicio="abc", data_fim="2024-12-31")
+
+    def test_ordem_invertida_propaga_validation_error(self):
+        s = _DummyScraper("v7")
+        with pytest.raises(ValidationError, match="não pode ser posterior"):
+            s._validar_parametros(data_inicio="2024-12-31", data_fim="2024-01-01")
+
+
+class TestCreateDownloadDir:
+    def test_cria_diretorio(self):
+        s = _DummyScraper("dl")
+        path = s._create_download_dir()
+        assert os.path.isdir(path)
+        assert s.nome_buscador in path
+
+    def test_chamadas_sequenciais_geram_paths_diferentes(self, mocker):
+        """Mock datetime para garantir timestamps distintos."""
+        s = _DummyScraper("dl2")
+        fake_dates = iter(["20240101120000", "20240101120001"])
+
+        def fake_now():
+            class _F:
+                @staticmethod
+                def strftime(_fmt):
+                    return next(fake_dates)
+            return _F()
+
+        mocker.patch("raspe.abstract_scraper.datetime", **{"now": fake_now})
+        p1 = s._create_download_dir()
+        p2 = s._create_download_dir()
+        assert p1 != p2
+
+
+class TestParseData:
+    def test_consolida_arquivos_html(self, tmp_path):
+        s = _DummyScraper("pd1")
+        f1 = tmp_path / "a.html"
+        f2 = tmp_path / "b.html"
+        f1.write_text("conteudo A", encoding="utf-8")
+        f2.write_text("conteudo B", encoding="utf-8")
+
+        df = s._parse_data(str(tmp_path))
+        assert len(df) == 2
+        assert {"conteudo A", "conteudo B"} <= set(df["content"])
+
+    def test_diretorio_vazio_retorna_df_vazio(self, tmp_path):
+        s = _DummyScraper("pd2")
+        df = s._parse_data(str(tmp_path))
+        assert df.empty
+
+    def test_erro_em_arquivo_isolado_nao_aborta(self, tmp_path, mocker):
+        """Se _parse_page levantar, o arquivo é ignorado mas os demais entram."""
+        s = _DummyScraper("pd3")
+        f1 = tmp_path / "ok.html"
+        f2 = tmp_path / "broken.html"
+        f1.write_text("ok", encoding="utf-8")
+        f2.write_text("broken", encoding="utf-8")
+
+        original_parse = s._parse_page
+
+        def maybe_fail(path):
+            if "broken" in path:
+                raise ValueError("simulated parse error")
+            return original_parse(path)
+
+        mocker.patch.object(s, "_parse_page", side_effect=maybe_fail)
+
+        df = s._parse_data(str(tmp_path))
+        assert len(df) == 1
+        assert df.iloc[0]["content"] == "ok"
+
+
+class TestScrapeAlias:
+    def test_scrape_chama_raspar(self, mocker):
+        s = _DummyScraper("alias")
+        mock_raspar = mocker.patch.object(s, "raspar", return_value=pd.DataFrame({"x": [1]}))
+        result = s.scrape(termo="x")
+        mock_raspar.assert_called_once_with(termo="x")
+        assert len(result) == 1

--- a/tests/test_abstract_scraper.py
+++ b/tests/test_abstract_scraper.py
@@ -106,17 +106,14 @@ class TestCreateDownloadDir:
 
     def test_chamadas_sequenciais_geram_paths_diferentes(self, mocker):
         """Mock datetime para garantir timestamps distintos."""
+        from datetime import datetime as real_datetime
+
         s = _DummyScraper("dl2")
-        fake_dates = iter(["20240101120000", "20240101120001"])
-
-        def fake_now():
-            class _F:
-                @staticmethod
-                def strftime(_fmt):
-                    return next(fake_dates)
-            return _F()
-
-        mocker.patch("raspe.abstract_scraper.datetime", **{"now": fake_now})
+        mock_dt = mocker.patch("raspe.abstract_scraper.datetime")
+        mock_dt.now.side_effect = [
+            real_datetime(2024, 1, 1, 12, 0, 0),
+            real_datetime(2024, 1, 1, 12, 0, 1),
+        ]
         p1 = s._create_download_dir()
         p2 = s._create_download_dir()
         assert p1 != p2

--- a/tests/test_base_scraper.py
+++ b/tests/test_base_scraper.py
@@ -221,6 +221,40 @@ class TestRasparBuscaUnica:
         df = scraper.raspar(termo="x")
         assert df.empty
 
+    @responses.activate
+    def test_debug_true_preserva_download_dir(self, mocker):
+        """Com debug=True, o diretório de download não é removido após raspar()."""
+        import os
+
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<total>1</total>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<r>x</r>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+
+        # Captura o path retornado por _download_data para verificar depois
+        captured: dict[str, str] = {}
+        scraper = _DummyHTTPScraper(debug=True)
+        original_download = scraper._download_data
+
+        def capture_path(**kwargs):
+            path = original_download(**kwargs)
+            captured["path"] = path
+            return path
+
+        mocker.patch.object(scraper, "_download_data", side_effect=capture_path)
+
+        scraper.raspar(termo="x")
+        assert "path" in captured
+        # Com debug=True, o diretório deve continuar existindo
+        assert os.path.isdir(captured["path"])
+
 
 class TestRasparListaTermos:
     @responses.activate
@@ -374,6 +408,23 @@ class TestRequestWithRetry:
         # Nenhum sleep deve ter sido chamado para 4xx
         sleep_mock.assert_not_called()
 
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_max_retries_override(self, mocker):
+        """O parâmetro max_retries sobrescreve self.max_retries."""
+        mocker.patch("time.sleep")
+        # 2 tentativas, ambas 503 → deve levantar após a segunda
+        for _ in range(2):
+            responses.add(
+                responses.GET, "http://example.com/api",
+                status=503, body="indisponivel",
+            )
+
+        scraper = _DummyHTTPScraper()
+        # self.max_retries=3, mas o override fixa em 2
+        with pytest.raises(APIError) as exc_info:
+            scraper._request_with_retry({"q": "x"}, max_retries=2)
+        assert exc_info.value.status_code == 503
+
 
 # ---------------------------------------------------------------------------
 # Helpers internos: _set_query_atual, _set_paginas, _set_r
@@ -414,6 +465,13 @@ class TestSetPaginas:
         result = scraper._set_paginas(None, None)
         assert list(result) == []
 
+    def test_paginas_com_step_custom(self):
+        """``range`` com step != 1 preserva o step ao clipar em n_pags."""
+        scraper = _DummyHTTPScraper()
+        result = scraper._set_paginas(range(1, 10, 2), 8)
+        # start=1, stop=min(10, 9)=9, step=2 → [1, 3, 5, 7]
+        assert list(result) == [1, 3, 5, 7]
+
 
 class TestSetR:
     @responses.activate
@@ -453,12 +511,25 @@ class TestSetR:
 class TestGetNPags:
     @responses.activate(registry=registries.OrderedRegistry)
     def test_erro_persistente_retorna_zero(self, mocker):
-        """Quando _request_with_retry levanta, _get_n_pags devolve 0."""
+        """Quando _request_with_retry levanta APIError, _get_n_pags devolve 0."""
         mocker.patch("time.sleep")
         for _ in range(3):
             responses.add(
                 responses.GET, "http://example.com/api",
                 status=500, body="erro",
+            )
+
+        scraper = _DummyHTTPScraper()
+        assert scraper._get_n_pags({"q": "x"}) == 0
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_rate_limit_persistente_retorna_zero(self, mocker):
+        """Rate limit que esgota retries também é absorvido por _get_n_pags."""
+        mocker.patch("time.sleep")
+        for _ in range(3):
+            responses.add(
+                responses.GET, "http://example.com/api",
+                status=429, headers={"Retry-After": "1"}, body="",
             )
 
         scraper = _DummyHTTPScraper()

--- a/tests/test_base_scraper.py
+++ b/tests/test_base_scraper.py
@@ -1,0 +1,465 @@
+"""Testes unitários para BaseScraper.
+
+Usa ``_DummyHTTPScraper`` (subclasse mínima) para exercitar o fluxo
+``raspar()`` → ``_download_data()`` → ``_request_with_retry()`` →
+``_parse_data()`` sem tocar a rede (via ``responses``) e sem tocar o relógio
+(via ``mocker.patch("time.sleep")``).
+"""
+
+import re
+from typing import Any, Literal
+
+import pandas as pd
+import pytest
+import requests
+import responses
+from responses import matchers, registries
+
+from raspe.base_scraper import BaseScraper
+from raspe.exceptions import APIError, RateLimitError
+
+
+class _DummyHTTPScraper(BaseScraper):
+    """Subclasse concreta com lógica mínima para alimentar os testes."""
+
+    def __init__(self, debug: bool = False, api_method: Literal['GET', 'POST'] = 'GET'):
+        super().__init__("DUMMY", debug=debug)
+        self._api_base = "http://example.com/api"
+        self._type: Literal['HTML'] = 'HTML'
+        self._query_page_name = 'page'
+        self._api_method: Literal['GET', 'POST'] = api_method
+        self.sleep_time = 0  # eliminamos sleep entre páginas além do mock
+
+    @property
+    def api_base(self) -> str:
+        return self._api_base
+
+    @property
+    def type(self) -> Literal['HTML']:
+        return self._type
+
+    @property
+    def query_page_name(self) -> str:
+        return self._query_page_name
+
+    @property
+    def api_method(self) -> Literal['GET', 'POST']:
+        return self._api_method
+
+    def _set_query_base(self, **kwargs) -> dict[str, Any]:
+        return {"q": str(kwargs.get("termo", "default"))}
+
+    def _find_n_pags(self, r0: requests.Response) -> int:
+        m = re.search(r"<total>(\d+)</total>", r0.text)
+        return int(m.group(1)) if m else 0
+
+    def _parse_page(self, path: str) -> pd.DataFrame:
+        with open(path, "r", encoding="utf-8") as f:
+            return pd.DataFrame({"content": [f.read()]})
+
+
+# ---------------------------------------------------------------------------
+# Fluxo principal: raspar() → _download_data()
+# ---------------------------------------------------------------------------
+
+
+class TestRasparBuscaUnica:
+    @responses.activate
+    def test_raspar_uma_pagina(self, mocker):
+        """Fluxo completo com 1 página: 1 request inicial + 1 de página.
+
+        Como 'termo' está na lista de parâmetros reconhecidos como busca
+        (junto com 'pesquisa', 'q', 'query'), o DataFrame final ganha
+        coluna ``termo_busca``.
+        """
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET,
+            "http://example.com/api",
+            body="<total>1</total>",
+            status=200,
+            content_type="text/html; charset=utf-8",
+            match=[matchers.query_param_matcher({"q": "termo1"})],
+        )
+        responses.add(
+            responses.GET,
+            "http://example.com/api",
+            body="<resultado>item</resultado>",
+            status=200,
+            content_type="text/html; charset=utf-8",
+            match=[matchers.query_param_matcher({"q": "termo1", "page": "1"})],
+        )
+
+        scraper = _DummyHTTPScraper()
+        df = scraper.raspar(termo="termo1")
+
+        assert not df.empty
+        assert "termo_busca" in df.columns
+        assert df["termo_busca"].iloc[0] == "termo1"
+
+    @responses.activate
+    def test_raspar_adiciona_termo_busca_para_param_pesquisa(self, mocker):
+        """Quando o param de busca é 'pesquisa', o DataFrame ganha coluna 'termo_busca'."""
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<total>1</total>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<resultado>item</resultado>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+
+        scraper = _DummyHTTPScraper()
+
+        # Sobrescreve _set_query_base para usar 'pesquisa' como termo
+        scraper._set_query_base = lambda **kw: {"q": str(kw.get("pesquisa", ""))}
+
+        df = scraper.raspar(pesquisa="meio ambiente")
+        assert "termo_busca" in df.columns
+        assert df["termo_busca"].iloc[0] == "meio ambiente"
+
+    @responses.activate
+    def test_raspar_paginacao_completa(self, mocker):
+        """3 páginas: 1 request inicial + 3 de página, cada uma com body próprio."""
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<total>3</total>", status=200,
+            content_type="text/html; charset=utf-8",
+            match=[matchers.query_param_matcher({"q": "x"})],
+        )
+        for pag in range(1, 4):
+            responses.add(
+                responses.GET, "http://example.com/api",
+                body=f"<r>pagina{pag}</r>", status=200,
+                content_type="text/html; charset=utf-8",
+                match=[matchers.query_param_matcher({"q": "x", "page": str(pag)})],
+            )
+
+        scraper = _DummyHTTPScraper()
+        df = scraper.raspar(termo="x")
+        assert len(df) == 3
+
+    @responses.activate
+    def test_raspar_zero_paginas(self, mocker):
+        """Quando _find_n_pags retorna 0, nenhuma página é baixada."""
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<total>0</total>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+        scraper = _DummyHTTPScraper()
+        df = scraper.raspar(termo="vazio")
+        assert df.empty
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_raspar_pula_pagina_com_erro_5xx(self, mocker):
+        """Páginas individuais com 5xx são puladas (não levantam) - apenas
+        a request inicial usa _request_with_retry; downloads de página
+        seguem fluxo direto.
+        """
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<total>2</total>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<r>ok</r>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="erro", status=503,
+        )
+
+        scraper = _DummyHTTPScraper()
+        df = scraper.raspar(termo="x")
+        # Apenas 1 página foi salva (a outra deu 503 e foi pulada)
+        assert len(df) == 1
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_raspar_pula_pagina_com_excecao(self, mocker):
+        """Exceções de rede em páginas individuais são logadas e puladas."""
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<total>2</total>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body=ConnectionError("falha de rede"),
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<r>ok</r>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+
+        scraper = _DummyHTTPScraper()
+        df = scraper.raspar(termo="x")
+        assert len(df) == 1
+
+    @responses.activate
+    def test_raspar_paginas_nao_iteravel_usa_fallback(self, mocker):
+        """Se _set_paginas devolver algo não iterável, usa range vazio."""
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="<total>1</total>", status=200,
+            content_type="text/html; charset=utf-8",
+        )
+
+        scraper = _DummyHTTPScraper()
+        mocker.patch.object(scraper, "_set_paginas", return_value=42)  # int não iterável
+        df = scraper.raspar(termo="x")
+        assert df.empty
+
+
+class TestRasparListaTermos:
+    @responses.activate
+    def test_lista_de_termos_concatena_resultados(self, mocker):
+        """termo=['a','b'] dispara 2 buscas com termo_busca correspondente."""
+        mocker.patch("time.sleep")
+        for termo in ["a", "b"]:
+            responses.add(
+                responses.GET, "http://example.com/api",
+                body="<total>1</total>", status=200,
+                content_type="text/html; charset=utf-8",
+                match=[matchers.query_param_matcher({"q": termo})],
+            )
+            responses.add(
+                responses.GET, "http://example.com/api",
+                body=f"<r>{termo}</r>", status=200,
+                content_type="text/html; charset=utf-8",
+                match=[matchers.query_param_matcher({"q": termo, "page": "1"})],
+            )
+
+        scraper = _DummyHTTPScraper()
+        df = scraper.raspar(termo=["a", "b"])
+        assert len(df) == 2
+        assert set(df["termo_busca"]) == {"a", "b"}
+
+    def test_lista_em_multiplos_params_levanta_valueerror(self, mocker):
+        """raspar() só suporta lista em um único parâmetro."""
+        mocker.patch("time.sleep")
+        scraper = _DummyHTTPScraper()
+        with pytest.raises(ValueError, match="só suporta lista"):
+            scraper.raspar(termo=["a"], outro=["x"])
+
+
+# ---------------------------------------------------------------------------
+# _request_with_retry: 429, 5xx e 4xx
+# ---------------------------------------------------------------------------
+
+
+class TestRequestWithRetry:
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_429_com_retry_after_aguarda_e_retenta(self, mocker):
+        sleep_mock = mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=429, headers={"Retry-After": "5"}, body="",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=200, body="ok",
+        )
+
+        scraper = _DummyHTTPScraper()
+        r = scraper._request_with_retry({"q": "x"})
+        assert r.status_code == 200
+        # Deve ter chamado sleep com 5s (do Retry-After)
+        sleep_mock.assert_any_call(5)
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_429_retry_after_invalido_cai_em_backoff(self, mocker):
+        sleep_mock = mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=429, headers={"Retry-After": "nao-numero"}, body="",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=200, body="ok",
+        )
+
+        scraper = _DummyHTTPScraper()
+        r = scraper._request_with_retry({"q": "x"})
+        assert r.status_code == 200
+        # Backoff exponencial: 2**0 = 1
+        sleep_mock.assert_any_call(1)
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_429_sem_retry_after_usa_backoff_exponencial(self, mocker):
+        sleep_mock = mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=429, body="",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=200, body="ok",
+        )
+
+        scraper = _DummyHTTPScraper()
+        r = scraper._request_with_retry({"q": "x"})
+        assert r.status_code == 200
+        sleep_mock.assert_any_call(1)
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_429_esgota_levanta_rate_limit_error(self, mocker):
+        mocker.patch("time.sleep")
+        # 3 tentativas (max_retries padrão), todas 429
+        for _ in range(3):
+            responses.add(
+                responses.GET, "http://example.com/api",
+                status=429, headers={"Retry-After": "1"}, body="",
+            )
+
+        scraper = _DummyHTTPScraper()
+        with pytest.raises(RateLimitError) as exc_info:
+            scraper._request_with_retry({"q": "x"})
+        assert exc_info.value.retry_after == 1
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_5xx_recupera_apos_retry(self, mocker):
+        mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=500, body="err",
+        )
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=200, body="ok",
+        )
+
+        scraper = _DummyHTTPScraper()
+        r = scraper._request_with_retry({"q": "x"})
+        assert r.status_code == 200
+
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_5xx_esgota_levanta_api_error(self, mocker):
+        mocker.patch("time.sleep")
+        for _ in range(3):
+            responses.add(
+                responses.GET, "http://example.com/api",
+                status=503, body="indisponivel",
+            )
+
+        scraper = _DummyHTTPScraper()
+        with pytest.raises(APIError) as exc_info:
+            scraper._request_with_retry({"q": "x"})
+        assert exc_info.value.status_code == 503
+        assert "indisponivel" in exc_info.value.response_text
+
+    @responses.activate
+    def test_4xx_nao_retenta(self, mocker):
+        """Erros 4xx (exceto 429) retornam imediatamente sem retry."""
+        sleep_mock = mocker.patch("time.sleep")
+        responses.add(
+            responses.GET, "http://example.com/api",
+            status=404, body="not found",
+        )
+
+        scraper = _DummyHTTPScraper()
+        r = scraper._request_with_retry({"q": "x"})
+        assert r.status_code == 404
+        # Nenhum sleep deve ter sido chamado para 4xx
+        sleep_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Helpers internos: _set_query_atual, _set_paginas, _set_r
+# ---------------------------------------------------------------------------
+
+
+class TestSetQueryAtual:
+    def test_aplica_multiplier_e_increment(self):
+        scraper = _DummyHTTPScraper()
+        scraper.query_page_multiplier = 10
+        scraper.query_page_increment = -10
+        query = scraper._set_query_atual({"q": "x"}, pag=2)
+        # page = 2*10 + (-10) = 10
+        assert query["page"] == 10
+
+    def test_old_page_name_recebe_pagina_anterior(self):
+        scraper = _DummyHTTPScraper()
+        scraper.old_page_name = "page_anterior"
+        query = scraper._set_query_atual({"q": "x"}, pag=3)
+        assert query["page"] == 3
+        assert query["page_anterior"] == 2
+
+
+class TestSetPaginas:
+    def test_sem_paginas_pega_todas(self):
+        scraper = _DummyHTTPScraper()
+        result = scraper._set_paginas(None, 5)
+        assert list(result) == [1, 2, 3, 4, 5]
+
+    def test_paginas_explicitas_clipam_em_n_pags(self):
+        scraper = _DummyHTTPScraper()
+        # Pediu 1-100 mas só há 3 páginas; deve clipar
+        result = scraper._set_paginas(range(1, 100), 3)
+        assert list(result) == [1, 2, 3]
+
+    def test_n_pags_none_vira_zero(self):
+        scraper = _DummyHTTPScraper()
+        result = scraper._set_paginas(None, None)
+        assert list(result) == []
+
+
+class TestSetR:
+    @responses.activate
+    def test_post_envia_data(self):
+        responses.add(
+            responses.POST, "http://example.com/api",
+            body="ok", status=200,
+            match=[matchers.urlencoded_params_matcher({"q": "x"})],
+        )
+        scraper = _DummyHTTPScraper(api_method='POST')
+        r = scraper._set_r({"q": "x"})
+        assert r.status_code == 200
+
+    @responses.activate
+    def test_get_envia_params(self):
+        responses.add(
+            responses.GET, "http://example.com/api",
+            body="ok", status=200,
+            match=[matchers.query_param_matcher({"q": "x"})],
+        )
+        scraper = _DummyHTTPScraper(api_method='GET')
+        r = scraper._set_r({"q": "x"})
+        assert r.status_code == 200
+
+    def test_metodo_invalido_levanta_valueerror(self):
+        scraper = _DummyHTTPScraper()
+        scraper._api_method = 'PATCH'  # type: ignore[assignment]
+        with pytest.raises(ValueError, match="Método de API inválido"):
+            scraper._set_r({"q": "x"})
+
+
+# ---------------------------------------------------------------------------
+# _get_n_pags: tratamento de erro da requisição inicial
+# ---------------------------------------------------------------------------
+
+
+class TestGetNPags:
+    @responses.activate(registry=registries.OrderedRegistry)
+    def test_erro_persistente_retorna_zero(self, mocker):
+        """Quando _request_with_retry levanta, _get_n_pags devolve 0."""
+        mocker.patch("time.sleep")
+        for _ in range(3):
+            responses.add(
+                responses.GET, "http://example.com/api",
+                status=500, body="erro",
+            )
+
+        scraper = _DummyHTTPScraper()
+        assert scraper._get_n_pags({"q": "x"}) == 0

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,123 @@
+"""Testes unitários para raspe.exceptions.
+
+Cobre a hierarquia de exceções customizadas, atributos opcionais e o alias
+de retrocompatibilidade ``SeleniumError``.
+"""
+
+import pytest
+
+from raspe.exceptions import (
+    APIError,
+    APIKeyError,
+    BrowserError,
+    DriverNotInstalledError,
+    RateLimitError,
+    ScraperError,
+    SeleniumError,
+    ValidationError,
+)
+
+
+class TestScraperError:
+    """ScraperError é a raiz da hierarquia de exceções."""
+
+    def test_eh_subclasse_de_exception(self):
+        assert issubclass(ScraperError, Exception)
+
+    def test_mensagem_preserved(self):
+        exc = ScraperError("mensagem de teste")
+        assert str(exc) == "mensagem de teste"
+
+    def test_pode_ser_levantada_e_capturada(self):
+        with pytest.raises(ScraperError, match="boom"):
+            raise ScraperError("boom")
+
+
+class TestAPIKeyError:
+    """APIKeyError herda de ScraperError."""
+
+    def test_hierarquia(self):
+        exc = APIKeyError("chave inválida")
+        assert isinstance(exc, ScraperError)
+        assert isinstance(exc, APIKeyError)
+
+    def test_capturavel_como_scraper_error(self):
+        with pytest.raises(ScraperError):
+            raise APIKeyError("falta API key")
+
+
+class TestRateLimitError:
+    """RateLimitError carrega retry_after opcional."""
+
+    def test_hierarquia(self):
+        exc = RateLimitError("rate limit")
+        assert isinstance(exc, ScraperError)
+
+    def test_sem_retry_after(self):
+        exc = RateLimitError("rate limit")
+        assert exc.retry_after is None
+
+    def test_com_retry_after(self):
+        exc = RateLimitError("rate limit", retry_after=60)
+        assert exc.retry_after == 60
+
+    def test_mensagem_preserved(self):
+        exc = RateLimitError("excedeu limite", retry_after=30)
+        assert "excedeu limite" in str(exc)
+
+
+class TestAPIError:
+    """APIError carrega status_code e response_text (truncado em 500 chars)."""
+
+    def test_hierarquia(self):
+        exc = APIError("erro na api")
+        assert isinstance(exc, ScraperError)
+
+    def test_defaults(self):
+        exc = APIError("falha")
+        assert exc.status_code is None
+        assert exc.response_text == ""
+
+    def test_com_status_code_e_texto(self):
+        exc = APIError("erro 500", status_code=500, response_text="server panic")
+        assert exc.status_code == 500
+        assert exc.response_text == "server panic"
+
+    def test_response_text_truncado_em_500(self):
+        texto_longo = "x" * 1000
+        exc = APIError("erro", response_text=texto_longo)
+        assert len(exc.response_text) == 500
+
+    def test_response_text_none_safe(self):
+        exc = APIError("erro", response_text="")
+        assert exc.response_text == ""
+
+
+class TestValidationError:
+    """ValidationError herda de ScraperError."""
+
+    def test_hierarquia(self):
+        exc = ValidationError("data inválida")
+        assert isinstance(exc, ScraperError)
+
+    def test_capturavel_via_value_error_nao(self):
+        """ValidationError NÃO é um ValueError; capturar especificamente."""
+        with pytest.raises(ValidationError):
+            raise ValidationError("erro")
+
+
+class TestBrowserError:
+    """BrowserError e seus alias/sub-classes."""
+
+    def test_hierarquia(self):
+        exc = BrowserError("timeout")
+        assert isinstance(exc, ScraperError)
+
+    def test_selenium_error_eh_alias(self):
+        """SeleniumError é mantido como alias de BrowserError."""
+        assert SeleniumError is BrowserError
+
+    def test_driver_not_installed_eh_browser_error(self):
+        exc = DriverNotInstalledError("instale playwright")
+        assert isinstance(exc, BrowserError)
+        assert isinstance(exc, ScraperError)

--- a/tests/test_html_scraper.py
+++ b/tests/test_html_scraper.py
@@ -23,8 +23,12 @@ class TestHTMLScraper:
         assert soup.find("p").text == "bytes"
 
     def test_soup_it_html_invalido_nao_levanta(self):
-        """BeautifulSoup com html.parser é permissivo; entrada inválida vira soup vazio."""
+        """BeautifulSoup é permissivo; entrada inválida vira soup com o texto cru.
+
+        Assertiva por substring para tolerar diferenças entre parsers
+        (``html.parser`` vs. ``lxml`` vs. ``html5lib`` quanto a whitespace).
+        """
         client = _DummyHTMLClient()
         soup = client.soup_it("texto sem tags")
         assert isinstance(soup, BeautifulSoup)
-        assert soup.get_text() == "texto sem tags"
+        assert "texto sem tags" in soup.get_text()

--- a/tests/test_html_scraper.py
+++ b/tests/test_html_scraper.py
@@ -1,0 +1,30 @@
+"""Testes unitários para o mixin HTMLScraper."""
+
+from bs4 import BeautifulSoup
+
+from raspe.html_scraper import HTMLScraper
+
+
+class _DummyHTMLClient(HTMLScraper):
+    """Subclasse mínima para instanciar o mixin em testes."""
+
+
+class TestHTMLScraper:
+    def test_soup_it_aceita_string(self):
+        client = _DummyHTMLClient()
+        soup = client.soup_it("<html><body><p>oi</p></body></html>")
+        assert isinstance(soup, BeautifulSoup)
+        assert soup.find("p").text == "oi"
+
+    def test_soup_it_aceita_bytes(self):
+        client = _DummyHTMLClient()
+        soup = client.soup_it(b"<html><body><p>bytes</p></body></html>")
+        assert isinstance(soup, BeautifulSoup)
+        assert soup.find("p").text == "bytes"
+
+    def test_soup_it_html_invalido_nao_levanta(self):
+        """BeautifulSoup com html.parser é permissivo; entrada inválida vira soup vazio."""
+        client = _DummyHTMLClient()
+        soup = client.soup_it("texto sem tags")
+        assert isinstance(soup, BeautifulSoup)
+        assert soup.get_text() == "texto sem tags"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,88 @@
+"""Testes para as factory functions exportadas em raspe.__init__.
+
+Cada função é um wrapper trivial que instancia a classe scraper correspondente.
+Os scrapers Playwright (saudelegis, ans, anvisa) são lazy nos imports, portanto
+podem ser instanciados sem que o pacote ``playwright`` esteja disponível em
+tempo de teste — só falham quando ``_ensure_playwright()`` é chamado.
+"""
+
+import pytest
+
+import raspe
+from raspe.scrapers.ans import ScraperANS
+from raspe.scrapers.anvisa import ScraperANVISA
+from raspe.scrapers.camara import ScraperCamaraDeputados
+from raspe.scrapers.cfm import ScraperCFM
+from raspe.scrapers.folha import ScraperFolha
+from raspe.scrapers.ipea import IpeaScraper
+from raspe.scrapers.nyt import ScraperNYT
+from raspe.scrapers.presidencia import ScraperPresidencia
+from raspe.scrapers.saudelegis import ScraperSaudeLegis
+from raspe.scrapers.senado import ScraperSenadoFederal
+
+
+@pytest.fixture(autouse=True)
+def _mock_camara_prep_scrape(mocker):
+    """Evita rede no __init__ de ScraperCamaraDeputados."""
+    mocker.patch.object(ScraperCamaraDeputados, "_prep_scrape", return_value={})
+
+
+class TestFactoriesHTTP:
+    def test_presidencia(self):
+        assert isinstance(raspe.presidencia(), ScraperPresidencia)
+
+    def test_ipea(self):
+        assert isinstance(raspe.ipea(), IpeaScraper)
+
+    def test_senado(self):
+        assert isinstance(raspe.senado(), ScraperSenadoFederal)
+
+    def test_camara(self):
+        assert isinstance(raspe.camara(), ScraperCamaraDeputados)
+
+    def test_cfm(self):
+        assert isinstance(raspe.cfm(), ScraperCFM)
+
+    def test_folha(self):
+        assert isinstance(raspe.folha(), ScraperFolha)
+
+    def test_nyt_com_api_key(self):
+        assert isinstance(raspe.nyt(api_key="chave-de-teste"), ScraperNYT)
+
+
+class TestFactoriesPlaywright:
+    """Factories de scrapers Playwright instanciam sem importar o pacote."""
+
+    def test_saudelegis(self):
+        assert isinstance(raspe.saudelegis(), ScraperSaudeLegis)
+
+    def test_ans(self):
+        assert isinstance(raspe.ans(), ScraperANS)
+
+    def test_anvisa(self):
+        assert isinstance(raspe.anvisa(), ScraperANVISA)
+
+
+class TestExports:
+    def test_version_disponivel(self):
+        assert isinstance(raspe.__version__, str)
+
+    def test_funcoes_uteis_reexportadas(self):
+        """Funções utilitárias estão acessíveis a partir do pacote."""
+        assert callable(raspe.expand)
+        assert callable(raspe.remove_duplicates)
+        assert callable(raspe.extract)
+        assert callable(raspe.check)
+        assert callable(raspe.validar_data)
+        assert callable(raspe.validar_intervalo_datas)
+
+    def test_excecoes_reexportadas(self):
+        """As exceções customizadas são acessíveis pelo pacote raiz."""
+        assert raspe.ScraperError is not None
+        assert raspe.RateLimitError is not None
+        assert raspe.APIError is not None
+        assert raspe.ValidationError is not None
+        assert raspe.BrowserError is not None
+        assert raspe.SeleniumError is raspe.BrowserError
+        assert raspe.DriverNotInstalledError is not None
+        assert raspe.APIKeyError is not None

--- a/tests/test_scraper_manager.py
+++ b/tests/test_scraper_manager.py
@@ -1,0 +1,48 @@
+"""Testes unitários para a função `scraper()` do scraper_manager.
+
+A função é uma factory que mapeia nomes ("PRESIDENCIA", "IPEA", ...) para
+classes de scraper. Os scrapers não devem fazer rede em seus testes — para
+``ScraperCamaraDeputados``, que invoca ``_prep_scrape`` no ``__init__``
+(que faz GET na página inicial), mockamos o método antes da instanciação.
+"""
+
+import pytest
+
+from raspe.scraper_manager import scraper
+from raspe.scrapers.camara import ScraperCamaraDeputados
+from raspe.scrapers.ipea import IpeaScraper
+from raspe.scrapers.presidencia import ScraperPresidencia
+from raspe.scrapers.senado import ScraperSenadoFederal
+
+
+@pytest.fixture(autouse=True)
+def _mock_camara_prep_scrape(mocker):
+    """Evita rede no __init__ de ScraperCamaraDeputados (faz GET inicial)."""
+    mocker.patch.object(ScraperCamaraDeputados, "_prep_scrape", return_value={})
+
+
+class TestScraperFactory:
+    def test_presidencia(self):
+        instance = scraper("presidencia")
+        assert isinstance(instance, ScraperPresidencia)
+
+    def test_ipea(self):
+        instance = scraper("ipea")
+        assert isinstance(instance, IpeaScraper)
+
+    def test_senado(self):
+        instance = scraper("senado")
+        assert isinstance(instance, ScraperSenadoFederal)
+
+    def test_camara(self):
+        instance = scraper("camara")
+        assert isinstance(instance, ScraperCamaraDeputados)
+
+    def test_nome_case_insensitive(self):
+        """A função normaliza o nome com .upper(), aceitando minúsculas/misturas."""
+        assert isinstance(scraper("Presidencia"), ScraperPresidencia)
+        assert isinstance(scraper("IPEA"), IpeaScraper)
+
+    def test_nome_invalido_levanta_value_error(self):
+        with pytest.raises(ValueError, match="não é suportado"):
+            scraper("desconhecido")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,26 @@
-import os
+"""Testes unitários para raspe.utils.
+
+Cobre as funções públicas exportadas em ``raspe.utils``:
+
+* ``expand`` — converte expressão de busca em lista de combinações
+* ``remove_duplicates`` — dedup por coluna ``link`` agregando ``termo_busca``
+* ``start_session`` — cria ``requests.Session`` com headers padrão
+* ``extract`` — coleta texto de cada URL em uma coluna do DataFrame
+* ``check`` — conta ocorrências de cada termo em ``link_content``
+* ``validar_data`` — normaliza string de data para ISO 8601
+* ``validar_intervalo_datas`` — valida par (início, fim) com ordem
+"""
+
 import re
-from datetime import datetime
-from unittest.mock import MagicMock, patch
+import warnings
 
 import pandas as pd
 import pytest
+import requests
+import responses
 
-# Import functions from utils.py
-from raspe.utils import expand
+from raspe.exceptions import ValidationError
+from raspe.utils import check, expand, extract, remove_duplicates, start_session, validar_data, validar_intervalo_datas
 
 
 class TestExpand:
@@ -68,17 +81,12 @@ class TestExpand:
         result = expand(expr)
 
         expected = [
-            # Combinações de singular + singular
             'doença rara', 'doença ultrarrara',
             'síndrome rara', 'síndrome ultrarrara',
             'patologia rara', 'patologia ultrarrara',
-
-            # Combinações de plural + plural
             'doenças raras', 'doenças ultrarraras',
             'síndromes raras', 'síndromes ultrarraras',
             'patologias raras', 'patologias ultrarraras',
-
-            # Outras combinações
             'medicamento órfão',
             'medicamentos órfãos',
             'terapia órfã',
@@ -98,3 +106,240 @@ class TestExpand:
         expr = "termo1 E () E termo2"
         with pytest.raises(ValueError, match="Parênteses vazios"):
             expand(expr)
+
+
+class TestRemoveDuplicates:
+    """Testes para a função remove_duplicates() que deduplica por 'link'."""
+
+    def test_sem_duplicatas_preserva_dataframe(self):
+        """Sem duplicatas, todas as linhas permanecem (em qualquer ordem)."""
+        df = pd.DataFrame({
+            "link": ["http://a", "http://b", "http://c"],
+            "titulo": ["A", "B", "C"],
+            "termo_busca": ["x", "y", "z"],
+        })
+        result = remove_duplicates(df)
+        assert len(result) == 3
+        assert set(result["link"]) == {"http://a", "http://b", "http://c"}
+
+    def test_duplicatas_simples_agregam_termo_busca(self):
+        """Duas linhas com mesmo link → uma linha com termo_busca concatenado."""
+        df = pd.DataFrame({
+            "link": ["http://a", "http://a", "http://b"],
+            "titulo": ["A", "A", "B"],
+            "termo_busca": ["termo1", "termo2", "termo3"],
+        })
+        result = remove_duplicates(df)
+        assert len(result) == 2
+        row_a = result[result["link"] == "http://a"].iloc[0]
+        assert "termo1" in row_a["termo_busca"]
+        assert "termo2" in row_a["termo_busca"]
+
+    def test_colunas_extras_usam_first(self):
+        """Colunas além de link/termo_busca usam agregação 'first'."""
+        df = pd.DataFrame({
+            "link": ["http://a", "http://a"],
+            "titulo": ["Primeiro", "Segundo"],
+            "termo_busca": ["t1", "t2"],
+            "data": ["2024-01-01", "2024-01-02"],
+        })
+        result = remove_duplicates(df)
+        assert len(result) == 1
+        row = result.iloc[0]
+        assert row["titulo"] == "Primeiro"
+        assert row["data"] == "2024-01-01"
+
+    def test_dataframe_vazio(self):
+        """DataFrame vazio retorna vazio sem levantar exceção."""
+        df = pd.DataFrame({"link": [], "titulo": [], "termo_busca": []})
+        result = remove_duplicates(df)
+        assert len(result) == 0
+
+
+class TestStartSession:
+    """Testes para start_session() que cria requests.Session padronizada."""
+
+    def test_retorna_requests_session(self):
+        """A função retorna uma instância de requests.Session."""
+        session = start_session()
+        assert isinstance(session, requests.Session)
+
+    def test_headers_obrigatorios_configurados(self):
+        """Headers padrão estão configurados."""
+        session = start_session()
+        headers = session.headers
+        assert "User-Agent" in headers
+        assert "Mozilla" in headers["User-Agent"]
+        assert "Accept-Language" in headers
+        assert "pt-BR" in headers["Accept-Language"]
+        assert "Accept-Encoding" in headers
+        assert headers["Connection"] == "keep-alive"
+
+    def test_sessoes_independentes(self):
+        """Cada chamada retorna uma session independente."""
+        s1 = start_session()
+        s2 = start_session()
+        assert s1 is not s2
+
+
+class TestExtract:
+    """Testes para extract() que coleta conteúdo HTML de uma coluna de URLs."""
+
+    @responses.activate
+    def test_extract_baixa_e_extrai_texto(self, mocker):
+        """extract() faz GET em cada link e adiciona coluna {col}_content."""
+        mocker.patch("raspe.utils.time.sleep")
+
+        responses.add(
+            responses.GET,
+            "http://example.com/a",
+            body="<html><body>Conteúdo A</body></html>",
+            status=200,
+            content_type="text/html; charset=utf-8",
+        )
+        responses.add(
+            responses.GET,
+            "http://example.com/b",
+            body="<html><body>Conteúdo B</body></html>",
+            status=200,
+            content_type="text/html; charset=utf-8",
+        )
+
+        df = pd.DataFrame({"link": ["http://example.com/a", "http://example.com/b"]})
+
+        with warnings.catch_warnings():
+            # BeautifulSoup pode emitir MarkupResemblesLocatorWarning em corpos pequenos
+            warnings.simplefilter("ignore")
+            result = extract(df, "link")
+
+        assert "link_content" in result.columns
+        assert "Conteúdo A" in result["link_content"].iloc[0]
+        assert "Conteúdo B" in result["link_content"].iloc[1]
+
+    def test_extract_file_url_eh_pulado(self, mocker):
+        """Links file:// são pulados e geram string vazia (sem requisição)."""
+        mocker.patch("raspe.utils.time.sleep")
+        df = pd.DataFrame({"link": ["file:///tmp/local.html"]})
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = extract(df, "link")
+
+        assert result["link_content"].iloc[0] == ""
+
+    @responses.activate
+    def test_extract_erro_de_requisicao_resulta_em_string_vazia(self, mocker):
+        """Quando GET falha, a linha recebe string vazia ao invés de propagar."""
+        mocker.patch("raspe.utils.time.sleep")
+        responses.add(
+            responses.GET,
+            "http://example.com/broken",
+            body=ConnectionError("falha de rede"),
+        )
+        df = pd.DataFrame({"link": ["http://example.com/broken"]})
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = extract(df, "link")
+
+        assert result["link_content"].iloc[0] == ""
+
+
+class TestCheck:
+    """Testes para check() que conta termos de busca em link_content."""
+
+    def test_count_simples(self):
+        """check() adiciona uma coluna por palavra única em termo_busca."""
+        df = pd.DataFrame({
+            "termo_busca": ["medicamento órfão"],
+            "link_content": ["O medicamento órfão é raro. O medicamento custa caro."],
+        })
+        result = check(df)
+        assert "medicamento" in result.columns
+        assert "órfão" in result.columns
+        assert result["medicamento"].iloc[0] == 2
+        assert result["órfão"].iloc[0] == 1
+
+    def test_count_palavra_completa(self):
+        """check() conta apenas ocorrências como palavra completa."""
+        df = pd.DataFrame({
+            "termo_busca": ["rara"],
+            "link_content": ["doença rara, raras, ultrararas, rara."],
+        })
+        result = check(df)
+        # 'rara' aparece 2x como palavra isolada; 'raras' e 'ultrararas' não contam
+        assert result["rara"].iloc[0] == 2
+
+
+class TestValidarData:
+    """Testes para validar_data() que normaliza strings de data."""
+
+    def test_formato_iso(self):
+        assert validar_data("2024-01-15") == "2024-01-15"
+
+    def test_formato_brasileiro(self):
+        assert validar_data("15/01/2024") == "2024-01-15"
+
+    def test_formato_compacto(self):
+        assert validar_data("20240115") == "2024-01-15"
+
+    def test_none_retorna_none(self):
+        assert validar_data(None) is None
+
+    def test_string_vazia_retorna_none(self):
+        assert validar_data("") is None
+
+    def test_string_com_espacos_retorna_none(self):
+        assert validar_data("   ") is None
+
+    def test_formato_invalido_levanta_validation_error(self):
+        with pytest.raises(ValidationError, match="formato inválido"):
+            validar_data("15-01-2024")
+
+    def test_data_impossivel_levanta_validation_error(self):
+        """29/02/2023 não existe (2023 não é bissexto)."""
+        with pytest.raises(ValidationError, match="data impossível"):
+            validar_data("29/02/2023")
+
+    def test_mes_invalido_levanta_validation_error(self):
+        with pytest.raises(ValidationError, match="data impossível"):
+            validar_data("15/13/2024")
+
+    def test_nome_param_aparece_na_mensagem(self):
+        with pytest.raises(ValidationError, match="data_inicio"):
+            validar_data("abc", nome_param="data_inicio")
+
+
+class TestValidarIntervaloDatas:
+    """Testes para validar_intervalo_datas() que valida par (início, fim)."""
+
+    def test_ambos_none(self):
+        assert validar_intervalo_datas(None, None) == (None, None)
+
+    def test_apenas_inicio(self):
+        result = validar_intervalo_datas("2024-01-01", None)
+        assert result == ("2024-01-01", None)
+
+    def test_apenas_fim(self):
+        result = validar_intervalo_datas(None, "2024-12-31")
+        assert result == (None, "2024-12-31")
+
+    def test_ordem_correta_normaliza_cross_formato(self):
+        result = validar_intervalo_datas("01/01/2024", "20241231")
+        assert result == ("2024-01-01", "2024-12-31")
+
+    def test_ordem_invertida_levanta_validation_error(self):
+        with pytest.raises(ValidationError, match="não pode ser posterior"):
+            validar_intervalo_datas("2024-12-31", "2024-01-01")
+
+    def test_nomes_personalizados_aparecem_na_mensagem(self):
+        with pytest.raises(ValidationError, match="inicio_custom"):
+            validar_intervalo_datas(
+                "2024-12-31", "2024-01-01",
+                nome_inicio="inicio_custom",
+                nome_fim="fim_custom",
+            )
+
+    def test_propaga_validation_error_de_validar_data(self):
+        with pytest.raises(ValidationError, match="formato inválido"):
+            validar_intervalo_datas("invalida", "2024-12-31")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,6 @@ Cobre as funções públicas exportadas em ``raspe.utils``:
 """
 
 import re
-import warnings
 
 import pandas as pd
 import pytest
@@ -182,13 +181,25 @@ class TestStartSession:
         assert s1 is not s2
 
 
+@pytest.mark.filterwarnings("ignore::bs4.MarkupResemblesLocatorWarning")
+@pytest.mark.filterwarnings("ignore::bs4.GuessedAtParserWarning")
 class TestExtract:
-    """Testes para extract() que coleta conteúdo HTML de uma coluna de URLs."""
+    """Testes para extract() que coleta conteúdo HTML de uma coluna de URLs.
+
+    Markers ``filterwarnings`` silenciam dois warnings do BeautifulSoup que
+    aparecem nesses cenários e seriam transformados em erro pelo
+    ``filterwarnings = ["error"]`` global:
+
+    * ``MarkupResemblesLocatorWarning`` — corpo curto em alguns testes.
+    * ``GuessedAtParserWarning`` — ``raspe.utils.extract`` chama
+      ``BeautifulSoup`` sem ``features=...`` explícito. Suprimimos só os dois
+      warnings concretos, sem afrouxar a regra global.
+    """
 
     @responses.activate
     def test_extract_baixa_e_extrai_texto(self, mocker):
         """extract() faz GET em cada link e adiciona coluna {col}_content."""
-        mocker.patch("raspe.utils.time.sleep")
+        mocker.patch("time.sleep")
 
         responses.add(
             responses.GET,
@@ -206,11 +217,7 @@ class TestExtract:
         )
 
         df = pd.DataFrame({"link": ["http://example.com/a", "http://example.com/b"]})
-
-        with warnings.catch_warnings():
-            # BeautifulSoup pode emitir MarkupResemblesLocatorWarning em corpos pequenos
-            warnings.simplefilter("ignore")
-            result = extract(df, "link")
+        result = extract(df, "link")
 
         assert "link_content" in result.columns
         assert "Conteúdo A" in result["link_content"].iloc[0]
@@ -218,30 +225,22 @@ class TestExtract:
 
     def test_extract_file_url_eh_pulado(self, mocker):
         """Links file:// são pulados e geram string vazia (sem requisição)."""
-        mocker.patch("raspe.utils.time.sleep")
+        mocker.patch("time.sleep")
         df = pd.DataFrame({"link": ["file:///tmp/local.html"]})
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            result = extract(df, "link")
-
+        result = extract(df, "link")
         assert result["link_content"].iloc[0] == ""
 
     @responses.activate
     def test_extract_erro_de_requisicao_resulta_em_string_vazia(self, mocker):
         """Quando GET falha, a linha recebe string vazia ao invés de propagar."""
-        mocker.patch("raspe.utils.time.sleep")
+        mocker.patch("time.sleep")
         responses.add(
             responses.GET,
             "http://example.com/broken",
             body=ConnectionError("falha de rede"),
         )
         df = pd.DataFrame({"link": ["http://example.com/broken"]})
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            result = extract(df, "link")
-
+        result = extract(df, "link")
         assert result["link_content"].iloc[0] == ""
 
 


### PR DESCRIPTION
## Sumário

Primeiro de três PRs para levar o repositório de **18% → ≥80%** de cobertura de testes. Este PR cobre os módulos compartilhados (infra), elevando a cobertura para **49%**.

## O que muda

### Configuração de coverage (`pyproject.toml`)

- `[tool.coverage.run]` com `omit = ["src/raspe/playwright_scraper.py"]`
  - Esse arquivo só faz sentido testar com Playwright real; testes offline mockando a API async inteira seriam testes de mocks, não da lógica. Os scrapers concretos (`datalegis`, `saudelegis`, `ans`, `anvisa`) permanecem no denominador e ganharão testes mínimos de configuração no PR 3.
- `[tool.coverage.report]` com `exclude_lines` padrão (`pragma: no cover`, `TYPE_CHECKING`, `NotImplementedError`, `...`).
- **Não** adiciona `fail_under = 80` ainda — só no PR 3, quando a meta é atingida.

### Testes unitários (120 testes ao todo)

| Arquivo | Cobertura: antes → depois |
|---|---|
| `tests/test_utils.py` (expandido) | 51% → 99% |
| `tests/test_exceptions.py` (novo) | ~80% → 100% |
| `tests/test_html_scraper.py` (novo) | — → 100% |
| `tests/test_scraper_manager.py` (novo) | 0% → 100% |
| `tests/test_abstract_scraper.py` (novo) | 34% → 100% |
| `tests/test_base_scraper.py` (novo) | 15% → 99% |
| `tests/test_init.py` (novo) | 64% → 100% |

Destaques:
- `_request_with_retry` testado com 429 (com e sem `Retry-After`), 5xx (recupera e esgota) e 4xx (sem retry), usando `OrderedRegistry`.
- Fluxo `raspar()` exercitado com 1 página, paginação completa, lista de termos, multi-params (`ValueError`), 5xx e exceções de rede em página individual (puladas), `_set_paginas` não-iterável (fallback).
- Helpers e validações de data (`validar_data`, `validar_intervalo_datas`) cobertos para todos os formatos e casos de erro.

## Padrões seguidos

Da checklist em `CLAUDE.md`:
- `@responses.activate` em todos os testes de rede.
- `mocker.patch("time.sleep")` em todas as funções com paginação/retry — **não autouse**.
- Schema validado por subset, nunca igualdade.
- `OrderedRegistry` em fluxos com múltiplas respostas distintas para a mesma URL.
- `filterwarnings = ["error"]` respeitado (nenhum warning escapa).

## Próximos PRs

- **PR 2**: contratos offline para 3 scrapers HTTP simples (`presidencia`, `folha`, `ipea`) com captura de samples reais. Alvo: ~62%.
- **PR 3**: contratos para `nyt`, `camara`, `senado`, `cfm` + testes mínimos para os 4 scrapers Playwright + `fail_under = 80`. Alvo: ≥80%.

## Test plan

- [x] `uv run pytest --cov=src/raspe --cov-report=term-missing` → 120 testes verde, 49% de cobertura
- [x] `uv run pre-commit run --files <arquivos>` → todos os hooks passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)