### PR TITLE
fix(base_scraper): não mutar query_base em _set_query_atual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ e o projeto adota [Versionamento Semântico](https://semver.org/lang/pt-BR/).
   como agregador `comunica_cnj`. Quem dependia de `raspe.cnj()` deve usar
   `juscraper.scraper("comunica_cnj").listar_comunicacoes(...)`.
 
+### Corrigido
+- `BaseScraper._set_query_atual` agora copia o dicionário recebido em vez
+  de mutar `query_base` in-place. Bug latente (não afetava o fluxo atual
+  de `_download_data`), mas vira armadilha em refactors futuros
+  (paralelização, cache, uso de `old_page_name`).
+
 ## [0.1.0] - 2025-05-15
 
 ### Adicionado

--- a/src/raspe/base_scraper.py
+++ b/src/raspe/base_scraper.py
@@ -260,7 +260,8 @@ class BaseScraper(AbstractScraper):
         return paginas
 
     def _set_query_atual(self, query_real: dict[str, Any], pag: int) -> dict[str, Any]:
-        query_atual = query_real
+        # Cópia rasa para não mutar o dicionário do caller (valores são str/int).
+        query_atual = dict(query_real)
 
         query_atual[self.query_page_name] = pag * self.query_page_multiplier + self.query_page_increment
 

--- a/tests/test_base_scraper.py
+++ b/tests/test_base_scraper.py
@@ -447,6 +447,19 @@ class TestSetQueryAtual:
         assert query["page"] == 3
         assert query["page_anterior"] == 2
 
+    def test_nao_muta_query_base(self):
+        scraper = _DummyHTTPScraper()
+        base = {"q": "x"}
+        scraper._set_query_atual(base, pag=1)
+        assert base == {"q": "x"}
+
+    def test_old_page_name_nao_muta_query_base(self):
+        scraper = _DummyHTTPScraper()
+        scraper.old_page_name = "page_anterior"
+        base = {"q": "x"}
+        scraper._set_query_atual(base, pag=3)
+        assert base == {"q": "x"}
+
 
 class TestSetPaginas:
     def test_sem_paginas_pega_todas(self):


### PR DESCRIPTION
## Resumo

- `BaseScraper._set_query_atual` agora copia o dicionário recebido (cópia
  rasa via `dict(query_real)`) em vez de mutar o `query_base` original do
  caller. Os valores das queries são `str`/`int`, então cópia rasa basta.
- Adiciona 2 testes de regressão em `TestSetQueryAtual` cobrindo o caso
  padrão e o caminho com `old_page_name` definido.
- Entrada `### Corrigido` em `## [Não lançado]` do `CHANGELOG.md`.

Bug latente — não afeta `_download_data` no fluxo atual (a chave `page` é
sobrescrita a cada iteração e ninguém inspeciona `query_base` depois do
loop), mas vira armadilha em refactors futuros: paralelização de páginas
(asyncio/threads viraria race condition silenciosa), cache derivado de
`query_base`, uso de `old_page_name`, ou reuso de literais entre chamadas
em testes.

Closes #38

## Test plan

- [x] `pytest tests/test_base_scraper.py::TestSetQueryAtual -v` — 4 passed
  (os 2 testes novos falham antes do fix e passam depois).
- [x] `pytest` — 130 passed, nenhuma regressão.
- [x] Pre-commit (trailing whitespace, isort, pylint, flake8, mypy,
  pyright) — todos verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)